### PR TITLE
Fix NPE-issue13

### DIFF
--- a/de.gebit.integrity.jenkins/pom.xml
+++ b/de.gebit.integrity.jenkins/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.580.1</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>de.gebit.integrity</groupId>
@@ -31,7 +31,15 @@
   <properties>
   	<sonar.exclusions>de/gebit/integrity/Messages.java</sonar.exclusions>
   </properties>
-    
+
+  <dependencies>
+	  <dependency>
+		  <groupId>org.jenkins-ci.plugins</groupId>
+		  <artifactId>junit</artifactId>
+		  <version>1.3</version>
+	  </dependency>
+  </dependencies>
+
   <!-- Override default Jenkins-CI repositories, since we currently don't want to release the plugin there yet -->
   <distributionManagement>
   	<repository>

--- a/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityCompoundTestResult.java
+++ b/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityCompoundTestResult.java
@@ -23,6 +23,7 @@ import com.thoughtworks.xstream.XStream;
 
 import hudson.XmlFile;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestObject;
@@ -95,9 +96,21 @@ public class IntegrityCompoundTestResult extends TabulatedResult {
 	private int callExceptionCount;
 
 	/**
+	 * The directory where persistent state of this result shall be kept.
+	 */
+	private String runRootDir;
+
+	/**
 	 * The action owning this result.
 	 */
 	private transient AbstractTestResultAction<?> parentAction;
+
+	/**
+	 * @param aRunRootDir the directory where persistent state of this result shall be kept
+	 */
+	public IntegrityCompoundTestResult(String aRunRootDir) {
+		this.runRootDir = aRunRootDir;
+	}
 
 	/**
 	 * Adds a child (single test result).
@@ -117,13 +130,21 @@ public class IntegrityCompoundTestResult extends TabulatedResult {
 		sortChildren();
 	}
 
+	/**
+	 * @return The absolute path to the file where persistent state of this result shall be kept
+	 */
+	public String getRunRootDir() {
+		return runRootDir;
+	}
+
 	private XmlFile getXmlFile() {
-		return new XmlFile(XSTREAM, new File(getOwner().getRootDir(), "integrityResultData.xml"));
+		return new XmlFile(XSTREAM, new File(getRunRootDir(), "integrityResultData.xml"));
 	}
 
 	private void sortChildren() {
 		Collections.sort(tempChildren, new Comparator<IntegrityTestResult>() {
 
+			@Override
 			public int compare(IntegrityTestResult o1, IntegrityTestResult o2) {
 				String tempFirstName = o1.getDisplayName() != null ? o1.getDisplayName() : "";
 				String tempSecondName = o2.getDisplayName() != null ? o2.getDisplayName() : "";
@@ -198,8 +219,8 @@ public class IntegrityCompoundTestResult extends TabulatedResult {
 	}
 
 	@Override
-	public AbstractBuild<?, ?> getOwner() {
-		return (parentAction == null ? null : parentAction.owner);
+	public Run<?, ?> getRun() {
+		return (parentAction == null ? null : parentAction.run);
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityTestResult.java
+++ b/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityTestResult.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TabulatedResult;
 import hudson.tasks.test.TestObject;
@@ -134,8 +134,8 @@ public class IntegrityTestResult extends TabulatedResult {
 	}
 
 	@Override
-	public AbstractBuild<?, ?> getOwner() {
-		return (parentAction == null ? null : parentAction.owner);
+	public Run<?, ?> getRun() {
+		return (parentAction == null ? null : parentAction.run);
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -147,6 +147,7 @@ public class IntegrityTestResult extends TabulatedResult {
 	/**
 	 * Returns the displayed name for this test.
 	 */
+	@Override
 	public String getDisplayName() {
 		if (displayName != null) {
 			return displayName;

--- a/de.gebit.integrity.jenkins/src/main/resources/de/gebit/integrity/Messages.properties
+++ b/de.gebit.integrity.jenkins/src/main/resources/de/gebit/integrity/Messages.properties
@@ -1,3 +1,4 @@
 TestResultActionDisplayName=Integrity Test Results
 NoTestResult=No test results found
 TestResult={0} {0,choice,0#tests|1#test|1<tests} passed, {1} failed, {2} {2,choice,0#exceptions|1#exception|1<exceptions} during tests plus {3} {3,choice,0#exceptions|1#exception|1<exceptions} during calls
+IntegrityTestResultRecorder_BadXML=Bad XML: {0}


### PR DESCRIPTION
IntegrityCompoundTestResult is a little broken wrt serialization:
It uses a file to serialize its child results instead of serializing
them into the output stream.

This approach is kinda ok when persisting the results to disk via
XStream
in jenkins, but it fails when serializing such objects from a jenkins
slave to its master over the wire.

This especially fails because the object from which to get the directory
where
the persistence file shall be created would needed to be serialized as
well. Since this class (AbstractBuild) is not serializable at al and the
field is even transient, this will never work.

As a workaround, we now explicitly pass the build's directory over the
wire. In the master/slave scenario, the results will only be available
on the
master when master and slave share the same persistence medium and
directory structure.

A better fix would obviously be to serialize child results also into the
given output stream instead of saving them to disk. But I leave this to
the maintainer, since I do not know the reasons for not doing this in
the first place.

While doing this, I also needed to
- port off of a few deprecated methods
- port to a newer jenkins LTS version
- add a dependency to the junit plugin, which holds all the test result
  classes
- add some @Override annotations

Fixes #13 and also relates to #8