### PR TITLE
Fix integrity history graph

### DIFF
--- a/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityCompoundTestResult.java
+++ b/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityCompoundTestResult.java
@@ -24,7 +24,6 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
 import com.thoughtworks.xstream.core.util.CustomObjectOutputStream;
 
 import hudson.XmlFile;
-import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.TabulatedResult;
@@ -38,7 +37,6 @@ import hudson.util.XStream2;
  * compound.
  * 
  * @author Rene Schneider - initial API and implementation
- * 
  */
 public class IntegrityCompoundTestResult extends TabulatedResult {
 
@@ -311,28 +309,4 @@ public class IntegrityCompoundTestResult extends TabulatedResult {
 	public int getExceptionCount() {
 		return getTestExceptionCount() + getCallExceptionCount();
 	}
-
-	/**
-	 * Gets the counter part of this {@link TestResult} in the specified run. This basically equals the upstream
-	 * function that is overridden here, but it also sets the parent action.
-	 * 
-	 * @return null if no such counter part exists.
-	 */
-	@Override
-	public TestResult getResultInBuild(AbstractBuild<?, ?> aBuild) {
-		AbstractTestResultAction<?> tempTestResultAction = aBuild.getAction(getParentAction().getClass());
-		if (tempTestResultAction == null) {
-			tempTestResultAction = aBuild.getAction(AbstractTestResultAction.class);
-		}
-		if (tempTestResultAction == null) {
-			return null;
-		} else {
-			TestResult tempResult = tempTestResultAction.findCorrespondingResult(this.getId());
-			if (tempResult != null) {
-				tempResult.setParentAction(tempTestResultAction);
-			}
-			return tempResult;
-		}
-	}
-
 }

--- a/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityProjectAction.java
+++ b/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityProjectAction.java
@@ -7,16 +7,15 @@
  *******************************************************************************/
 package de.gebit.integrity;
 
-import hudson.model.Action;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
 
 /**
  * The project action for Integrity Test Results. This class is responsible for displaying the Integrity overview on the
  * projects' pages, where the results of the last build and historical graphs etc. are shown.
  * 
  * @author Rene Schneider - initial API and implementation
- * 
  */
 public class IntegrityProjectAction implements Action {
 
@@ -34,14 +33,17 @@ public class IntegrityProjectAction implements Action {
 		this.project = aProject;
 	}
 
+	@Override
 	public String getIconFileName() {
 		return null;
 	}
 
+	@Override
 	public String getDisplayName() {
 		return null;
 	}
 
+	@Override
 	public String getUrlName() {
 		return "integrity";
 	}
@@ -66,6 +68,9 @@ public class IntegrityProjectAction implements Action {
 			return null;
 		}
 		IntegrityCompoundTestResult tempResult = tempLatestResults.getResult();
+		if (tempResult == null) {
+			return null;
+		}
 		return new IntegrityHistory(tempResult);
 	}
 

--- a/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityTestResultAction.java
+++ b/de.gebit.integrity.jenkins/src/main/java/de/gebit/integrity/IntegrityTestResultAction.java
@@ -23,7 +23,6 @@ import hudson.util.XStream2;
  * This result action is responsible for displaying the test result overview on the page of individual builds.
  * 
  * @author Rene Schneider - initial API and implementation
- * 
  */
 public class IntegrityTestResultAction extends AbstractTestResultAction<IntegrityTestResultAction>
 		implements StaplerProxy {
@@ -59,6 +58,15 @@ public class IntegrityTestResultAction extends AbstractTestResultAction<Integrit
 	public IntegrityTestResultAction(IntegrityCompoundTestResult aResult, BuildListener aListener) {
 		result = aResult;
 		aResult.setParentAction(this);
+	}
+
+	@Override
+	public Object readResolve() {
+		Object tempObject = super.readResolve();
+		if (result != null) {
+			result.setParentAction(this);
+		}
+		return tempObject;
 	}
 
 	@Override


### PR DESCRIPTION
The history graph was always broken for us since the parentAction of the IntegrityCompoundTestResult was never set after deserialization.